### PR TITLE
add unselectedColor (for am/pm and hour/minute)

### DIFF
--- a/lib/lib/ampm.dart
+++ b/lib/lib/ampm.dart
@@ -11,11 +11,14 @@ class AmPm extends StatelessWidget {
   /// Accent color to be used for the button
   final Color accentColor;
 
+  /// Accent color to be used for the unselected button
+  final Color unselectedColor;
+
   /// Default [TextStyle]
   final _style = TextStyle(fontSize: 20);
 
   /// Initialize the buttons
-  AmPm({this.selected, this.onChange, this.accentColor});
+  AmPm({this.selected, this.onChange, this.accentColor, this.unselectedColor});
 
   @override
   Widget build(BuildContext context) {
@@ -42,7 +45,7 @@ class AmPm extends StatelessWidget {
                   child: Text(
                     "am",
                     style: _style.copyWith(
-                      color: isAm ? accentColor : null,
+                      color: isAm ? accentColor : unselectedColor,
                       fontWeight: isAm ? FontWeight.bold : null,
                     ),
                   ),
@@ -66,7 +69,7 @@ class AmPm extends StatelessWidget {
                   child: Text(
                     "pm",
                     style: _style.copyWith(
-                      color: !isAm ? accentColor : null,
+                      color: !isAm ? accentColor : unselectedColor,
                       fontWeight: !isAm ? FontWeight.bold : null,
                     ),
                   ),

--- a/lib/lib/daynight_timepicker.dart
+++ b/lib/lib/daynight_timepicker.dart
@@ -50,6 +50,7 @@ PageRouteBuilder showPicker({
   void Function(DateTime) onChangeDateTime,
   bool is24HrFormat = false,
   Color accentColor,
+  Color unselectedColor,
   String cancelText = "cancel",
   String okText = "ok",
   Image sunAsset,
@@ -67,6 +68,7 @@ PageRouteBuilder showPicker({
       onChangeDateTime: onChangeDateTime,
       is24HrFormat: is24HrFormat,
       accentColor: accentColor,
+      unselectedColor: unselectedColor,
       cancelText: cancelText,
       okText: okText,
       sunAsset: sunAsset,
@@ -113,6 +115,9 @@ class _DayNightTimePicker extends StatefulWidget {
   /// Accent color of the TimePicker.
   final Color accentColor;
 
+  /// Accent color of unselected text.
+  final Color unselectedColor;
+
   /// Text displayed for the Cancel button.
   final String cancelText;
 
@@ -142,6 +147,7 @@ class _DayNightTimePicker extends StatefulWidget {
     this.onChangeDateTime,
     this.is24HrFormat = false,
     this.accentColor,
+    this.unselectedColor,
     this.cancelText = "cancel",
     this.okText = "ok",
     this.sunAsset,
@@ -279,6 +285,7 @@ class _DayNightTimePickerState extends State<_DayNightTimePicker> {
     final height = widget.is24HrFormat ? 200.0 : 240.0;
 
     final color = widget.accentColor ?? Theme.of(context).accentColor;
+    final unselectedColor = widget.unselectedColor ?? Colors.grey;
     final unselectedOpacity = 1.0;
 
     final double blurAmount = widget.blurredBackground ?? false ? 5 : 0;
@@ -317,6 +324,7 @@ class _DayNightTimePickerState extends State<_DayNightTimePicker> {
                     if (!widget.is24HrFormat)
                       AmPm(
                         accentColor: color,
+                        unselectedColor: unselectedColor,
                         selected: a,
                         onChange: (e) {
                           setState(() {
@@ -342,7 +350,9 @@ class _DayNightTimePickerState extends State<_DayNightTimePicker> {
                                   child: Text(
                                     "$hour",
                                     style: _commonTimeStyles.copyWith(
-                                        color: changingHour ? color : null),
+                                        color: changingHour
+                                            ? color
+                                            : unselectedColor),
                                   ),
                                 ),
                               ),
@@ -364,7 +374,9 @@ class _DayNightTimePickerState extends State<_DayNightTimePicker> {
                                   child: Text(
                                     "${padNumber(minute)}",
                                     style: _commonTimeStyles.copyWith(
-                                        color: !changingHour ? color : null),
+                                        color: !changingHour
+                                            ? color
+                                            : unselectedColor),
                                   ),
                                 ),
                               ),


### PR DESCRIPTION
I wasn't able to change the above mentioned colors, because I believe

```
  /// Default [TextStyle]
  final _style = TextStyle(fontSize: 20);
```

neglected my own theme colors.

With this commit, users can manually select the unselected/inactive color for both am/pm and hour/minute buttons.