### PR TITLE
add dialogInsetPadding

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ FlatButton(
 | **barrierColor**        | Color of the background of the [Modal].                                                                  |           `Colors.black45`           |
 | **borderRadius**        | Border radius of the [Container] in [double].                                                            |                `10.0`                |
 | **elevation**           | Elevation of the [Modal] in [double].                                                                    |                `12.0`                |
+| **dialogInsetPadding**  | Inset padding of the [Modal] in EdgeInsets.                                                              | `EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0)` |
 | **barrierDismissible**  | Whether clicking outside should dismiss the [Modal].                                                     |                `true`                |
 | **iosStylePicker**      | Whether to display a IOS style picker (Not exactly the same).                                            |               `false`                |
 | **hourLabel**           | The label to be displayed for `hour` picker. Only for _iosStylePicker_.                                  |              `'hours'`               |

--- a/lib/lib/day_night_timepicker_android.dart
+++ b/lib/lib/day_night_timepicker_android.dart
@@ -57,6 +57,9 @@ class DayNightTimePickerAndroid extends StatefulWidget {
   /// Elevation of the [Modal] in [double].
   final double? elevation;
 
+  /// Inset padding of the [Modal] in [EdgeInsets].
+  final EdgeInsets? dialogInsetPadding;
+
   /// Steps interval while changing [minute].
   final MinuteInterval? minuteInterval;
 
@@ -101,6 +104,7 @@ class DayNightTimePickerAndroid extends StatefulWidget {
     this.blurredBackground = false,
     this.borderRadius,
     this.elevation,
+    this.dialogInsetPadding,
     this.minuteInterval,
     this.disableMinute,
     this.disableHour,
@@ -261,6 +265,7 @@ class _DayNightTimePickerAndroidState extends State<DayNightTimePickerAndroid> {
     return BackdropFilter(
       filter: ImageFilter.blur(sigmaX: blurAmount, sigmaY: blurAmount),
       child: Dialog(
+        insetPadding: widget.dialogInsetPadding,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(borderRadius),
         ),

--- a/lib/lib/day_night_timepicker_ios.dart
+++ b/lib/lib/day_night_timepicker_ios.dart
@@ -58,6 +58,9 @@ class DayNightTimePickerIos extends StatefulWidget {
   /// Elevation of the [Modal] in [double].
   final double? elevation;
 
+  /// Inset padding of the [Modal] in [EdgeInsets].
+  final EdgeInsets? dialogInsetPadding;
+
   /// Label for the `hour` text.
   final String? hourLabel;
 
@@ -108,6 +111,7 @@ class DayNightTimePickerIos extends StatefulWidget {
     this.blurredBackground = false,
     this.borderRadius,
     this.elevation,
+    this.dialogInsetPadding,
     this.hourLabel,
     this.minuteLabel,
     this.minuteInterval,
@@ -341,6 +345,7 @@ class _DayNightTimePickerIosState extends State<DayNightTimePickerIos> {
     return BackdropFilter(
       filter: ImageFilter.blur(sigmaX: blurAmount, sigmaY: blurAmount),
       child: Dialog(
+        insetPadding: widget.dialogInsetPadding,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(borderRadius),
         ),

--- a/lib/lib/daynight_timepicker.dart
+++ b/lib/lib/daynight_timepicker.dart
@@ -37,6 +37,8 @@ import 'package:flutter/material.dart';
 ///
 /// **elevation** - Elevation of the [Modal] in double. Defaults to `12.0`.
 ///
+/// **dialogInsetPadding** - Inset padding of the [Modal] in EdgeInsets. Defaults to `EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0)`.
+///
 /// **barrierDismissible** - Whether clicking outside should dismiss the [Modal]. Defaults to `true`.
 ///
 /// **iosStylePicker** - Whether to display a IOS style picker (Not exactly the same). Defaults to `false`.
@@ -78,6 +80,7 @@ PageRouteBuilder showPicker({
   Color barrierColor = Colors.black45,
   double? borderRadius,
   double? elevation,
+  EdgeInsets? dialogInsetPadding = const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
   bool barrierDismissible = true,
   bool iosStylePicker = false,
   bool displayHeader = true,
@@ -132,6 +135,7 @@ PageRouteBuilder showPicker({
             blurredBackground: blurredBackground,
             borderRadius: borderRadius,
             elevation: elevation,
+            dialogInsetPadding: dialogInsetPadding,
             hourLabel: hourLabel,
             minuteLabel: minuteLabel,
             minuteInterval: minuteInterval,
@@ -161,6 +165,7 @@ PageRouteBuilder showPicker({
             blurredBackground: blurredBackground,
             borderRadius: borderRadius,
             elevation: elevation,
+            dialogInsetPadding: dialogInsetPadding,
             minuteInterval: minuteInterval,
             disableMinute: disableMinute,
             disableHour: disableHour,
@@ -227,6 +232,8 @@ PageRouteBuilder showPicker({
 ///
 /// **elevation** - Elevation of the [Modal] in double. Defaults to `12.0`.
 ///
+/// **dialogInsetPadding** - Inset padding of the [Modal] in EdgeInsets. Defaults to `EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0)`.
+///
 /// **barrierDismissible** - Whether clicking outside should dismiss the [Modal]. Defaults to `true`.
 ///
 /// **iosStylePicker** - Whether to display a IOS style picker (Not exactly the same). Defaults to `false`.
@@ -271,6 +278,7 @@ Widget createInlinePicker({
   Color barrierColor = Colors.black45,
   double? borderRadius,
   double? elevation,
+  EdgeInsets? dialogInsetPadding = const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
   bool barrierDismissible = true,
   bool iosStylePicker = false,
   String hourLabel = 'hours',
@@ -324,6 +332,7 @@ Widget createInlinePicker({
             blurredBackground: blurredBackground,
             borderRadius: borderRadius,
             elevation: elevation,
+            dialogInsetPadding: dialogInsetPadding,
             hourLabel: hourLabel,
             minuteLabel: minuteLabel,
             minuteInterval: minuteInterval,
@@ -359,6 +368,7 @@ Widget createInlinePicker({
             blurredBackground: blurredBackground,
             borderRadius: borderRadius,
             elevation: elevation,
+            dialogInsetPadding: dialogInsetPadding,
             minuteInterval: minuteInterval,
             disableMinute: disableMinute,
             disableHour: disableHour,


### PR DESCRIPTION
I was trying to create time picker by day_night_time_picker in my app style like below image.

![Simulator Screen Shot - iPhone 12 Pro - 2021-03-11 at 14 32 36](https://user-images.githubusercontent.com/22625638/110778278-63ae0480-8277-11eb-947f-b9c6fc554fd1.png)

But I could not remove Modal padding (below image) with the available parameters and features of day_night_time_picker.

![Simulator Screen Shot - iPhone 12 Pro - 2021-03-11 at 14 32 55](https://user-images.githubusercontent.com/22625638/110778604-cf906d00-8277-11eb-8c61-71c6a2163029.png)

I added dialogInsetPadding to your widget for this approach.