### PR TITLE
Text style customization added for ok/cancel buttons. Example's overflow bug has been fixed.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,77 +36,81 @@ class _HomeState extends State<Home> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text(
-              "Popup Picker Style",
-              style: Theme.of(context).textTheme.headline6,
-            ),
-            Text(
-              _time.format(context),
-              textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.headline1,
-            ),
-            SizedBox(height: 10),
-            TextButton(
-              style: TextButton.styleFrom(
-                backgroundColor: Theme.of(context).accentColor,
-              ),
-              onPressed: () {
-                Navigator.of(context).push(
-                  showPicker(
-                    context: context,
-                    value: _time,
-                    onChange: onTimeChanged,
-                    minuteInterval: MinuteInterval.FIVE,
-                    disableHour: false,
-                    disableMinute: false,
-                    minMinute: 7,
-                    maxMinute: 56,
-                    // Optional onChange to receive value as DateTime
-                    onChangeDateTime: (DateTime dateTime) {
-                      print(dateTime);
-                    },
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Text(
+                  "Popup Picker Style",
+                  style: Theme.of(context).textTheme.headline6,
+                ),
+                Text(
+                  _time.format(context),
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.headline1,
+                ),
+                SizedBox(height: 10),
+                TextButton(
+                  style: TextButton.styleFrom(
+                    backgroundColor: Theme.of(context).accentColor,
                   ),
-                );
-              },
-              child: Text(
-                "Open time picker",
-                style: TextStyle(color: Colors.white),
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      showPicker(
+                        context: context,
+                        value: _time,
+                        onChange: onTimeChanged,
+                        minuteInterval: MinuteInterval.FIVE,
+                        disableHour: false,
+                        disableMinute: false,
+                        minMinute: 7,
+                        maxMinute: 56,
+                        // Optional onChange to receive value as DateTime
+                        onChangeDateTime: (DateTime dateTime) {
+                          print(dateTime);
+                        },
+                      ),
+                    );
+                  },
+                  child: Text(
+                    "Open time picker",
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ),
+                SizedBox(height: 10),
+                Divider(),
+                SizedBox(height: 10),
+                Text(
+                  "Inline Picker Style",
+                  style: Theme.of(context).textTheme.headline6,
               ),
+                // Render inline widget
+                createInlinePicker(
+                  elevation: 1,
+                  value: _time,
+                  onChange: onTimeChanged,
+                  minuteInterval: MinuteInterval.FIVE,
+                  iosStylePicker: iosStyle,
+                  minMinute: 7,
+                  maxMinute: 56,
+                ),
+                Text(
+                  "IOS Style",
+                  style: Theme.of(context).textTheme.bodyText1,
+                ),
+                Switch(
+                  value: iosStyle,
+                  onChanged: (newVal) {
+                    setState(() {
+                      iosStyle = newVal;
+                    });
+                  },
+                )
+              ],
             ),
-            SizedBox(height: 10),
-            Divider(),
-            SizedBox(height: 10),
-            Text(
-              "Inline Picker Style",
-              style: Theme.of(context).textTheme.headline6,
-            ),
-            // Render inline widget
-            createInlinePicker(
-              elevation: 1,
-              value: _time,
-              onChange: onTimeChanged,
-              minuteInterval: MinuteInterval.FIVE,
-              iosStylePicker: iosStyle,
-              minMinute: 7,
-              maxMinute: 56,
-            ),
-            Text(
-              "IOS Style",
-              style: Theme.of(context).textTheme.bodyText1,
-            ),
-            Switch(
-              value: iosStyle,
-              onChanged: (newVal) {
-                setState(() {
-                  iosStyle = newVal;
-                });
-              },
-            )
-          ],
+          ),
         ),
       ),
     );

--- a/lib/lib/day_night_timepicker_android.dart
+++ b/lib/lib/day_night_timepicker_android.dart
@@ -89,6 +89,9 @@ class DayNightTimePickerAndroid extends StatefulWidget {
   /// Whether or not the minute picker is auto focus/selected.
   final bool focusMinutePicker;
 
+  /// Ok/Cancel button's text style [TextStyle]
+  TextStyle okCancelStyle;
+
   /// Initialize the picker [Widget]
   DayNightTimePickerAndroid({
     required this.value,
@@ -116,6 +119,7 @@ class DayNightTimePickerAndroid extends StatefulWidget {
     this.minMinute,
     this.isInlineWidget = false,
     this.focusMinutePicker = false,
+    this.okCancelStyle = const TextStyle(fontWeight: FontWeight.bold),
   }) {
     if (isInlineWidget) {
       this.cancelText = "reset";
@@ -143,11 +147,13 @@ class _DayNightTimePickerAndroidState extends State<DayNightTimePickerAndroid> {
   bool hourIsSelected = true;
 
   /// Default Ok/Cancel [TextStyle]
-  final okCancelStyle = const TextStyle(fontWeight: FontWeight.bold);
+  late TextStyle okCancelStyle;
 
   @override
   void initState() {
     bool _hourIsSelected = true;
+
+    okCancelStyle = widget.okCancelStyle;
 
     if (widget.focusMinutePicker || widget.disableHour!) {
       _hourIsSelected = false;

--- a/lib/lib/day_night_timepicker_ios.dart
+++ b/lib/lib/day_night_timepicker_ios.dart
@@ -96,6 +96,9 @@ class DayNightTimePickerIos extends StatefulWidget {
   /// Whether or not the minute picker is auto focus/selected.
   final bool focusMinutePicker;
 
+  /// Ok/Cancel button's text style [TextStyle]
+  TextStyle okCancelStyle;
+
   /// Initialize the picker [Widget]
   DayNightTimePickerIos({
     required this.value,
@@ -125,6 +128,7 @@ class DayNightTimePickerIos extends StatefulWidget {
     this.minMinute,
     this.isInlineWidget = false,
     this.focusMinutePicker = false,
+    this.okCancelStyle = const TextStyle(fontWeight: FontWeight.bold),
   }) {
     if (isInlineWidget) {
       this.cancelText = "reset";
@@ -151,7 +155,7 @@ class _DayNightTimePickerIosState extends State<DayNightTimePickerIos> {
   bool hourIsSelected = true;
 
   /// Default Ok/Cancel [TextStyle]
-  final okCancelStyle = const TextStyle(fontWeight: FontWeight.bold);
+  late TextStyle okCancelStyle;
 
   /// Controller for `hour` list
   FixedExtentScrollController? _hourController;
@@ -168,6 +172,8 @@ class _DayNightTimePickerIosState extends State<DayNightTimePickerIos> {
   @override
   void initState() {
     bool _hourIsSelected = true;
+
+    okCancelStyle = widget.okCancelStyle;
 
     if (widget.focusMinutePicker || widget.disableHour!) {
       _hourIsSelected = false;

--- a/lib/lib/daynight_timepicker.dart
+++ b/lib/lib/daynight_timepicker.dart
@@ -67,6 +67,7 @@ import 'package:flutter/material.dart';
 ///
 /// **themeData** - ThemeData to use for the widget.
 ///
+/// **okCancelStyle** - Ok/Cancel button's text style
 PageRouteBuilder showPicker({
   BuildContext? context,
   required TimeOfDay value,
@@ -100,6 +101,7 @@ PageRouteBuilder showPicker({
   // Infinity is used so that we can assert whether or not the user actually set a value
   double minHour = double.infinity,
   double maxHour = double.infinity,
+  TextStyle okCancelStyle = const TextStyle(fontWeight: FontWeight.bold)
 }) {
   if (minHour == double.infinity) {
     minHour = is24HrFormat ? 0 : 1;
@@ -153,6 +155,7 @@ PageRouteBuilder showPicker({
             minHour: minHour,
             minMinute: minMinute,
             focusMinutePicker: focusMinutePicker,
+            okCancelStyle: okCancelStyle,
           ),
         );
       } else {
@@ -182,6 +185,7 @@ PageRouteBuilder showPicker({
             minHour: minHour,
             minMinute: minMinute,
             focusMinutePicker: focusMinutePicker,
+            okCancelStyle: okCancelStyle,
           ),
         );
       }
@@ -273,6 +277,7 @@ PageRouteBuilder showPicker({
 ///
 /// **themeData** - ThemeData to use for the widget.
 ///
+/// **OkCancelStyle** - Custom text style for buttons.
 Widget createInlinePicker({
   BuildContext? context,
   required TimeOfDay value,
@@ -307,6 +312,8 @@ Widget createInlinePicker({
   // Infinity is used so that we can assert whether or not the user actually set a value
   double minHour = double.infinity,
   double maxHour = double.infinity,
+  TextStyle okCancelStyle: const TextStyle(fontWeight: FontWeight.bold),
+
 }) {
   if (minHour == double.infinity) {
     minHour = is24HrFormat ? 0 : 1;
@@ -362,6 +369,7 @@ Widget createInlinePicker({
             displayHeader: displayHeader,
             isOnValueChangeMode: isOnChangeValueMode,
             focusMinutePicker: focusMinutePicker,
+            okCancelStyle: okCancelStyle,
           ),
         );
       },
@@ -397,6 +405,7 @@ Widget createInlinePicker({
             displayHeader: displayHeader,
             isOnValueChangeMode: isOnChangeValueMode,
             focusMinutePicker: focusMinutePicker,
+            okCancelStyle: okCancelStyle,
           ),
         );
       },


### PR DESCRIPTION
Hello, 
I really enjoyed your widget however while I'm using, I realized that we cannot change text style of buttons. So, I wanted to make a small contribution. 
Keep it up with this great work! Well done. 

ps. In example's main file, I just added SafeArea and SingleChildScrollView widgets. Because view was overflowing on my emulator. 