### PR TITLE
Remove toUpperCase for both Ok and Cancel text

### DIFF
--- a/lib/lib/day_night_timepicker_android.dart
+++ b/lib/lib/day_night_timepicker_android.dart
@@ -408,14 +408,14 @@ class _DayNightTimePickerAndroidState extends State<DayNightTimePickerAndroid> {
                                   ),
                                   onPressed: onCancel,
                                   child: Text(
-                                    widget.cancelText.toUpperCase(),
+                                    widget.cancelText,
                                     style: okCancelStyle,
                                   ),
                                 ),
                                 TextButton(
                                   onPressed: onOk,
                                   child: Text(
-                                    widget.okText.toUpperCase(),
+                                    widget.okText,
                                     style: okCancelStyle,
                                   ),
                                   style: TextButton.styleFrom(

--- a/lib/lib/day_night_timepicker_ios.dart
+++ b/lib/lib/day_night_timepicker_ios.dart
@@ -492,14 +492,14 @@ class _DayNightTimePickerIosState extends State<DayNightTimePickerIos> {
                                   ),
                                   onPressed: onCancel,
                                   child: Text(
-                                    widget.cancelText.toUpperCase(),
+                                    widget.cancelText,
                                     style: okCancelStyle,
                                   ),
                                 ),
                                 TextButton(
                                   onPressed: onOk,
                                   child: Text(
-                                    widget.okText.toUpperCase(),
+                                    widget.okText,
                                     style: okCancelStyle,
                                   ),
                                   style: TextButton.styleFrom(


### PR DESCRIPTION
There's no need to uppercase the text. User can pass in uppercase text if they want.