### PR TITLE
Fix the initial hour on iOS

### DIFF
--- a/lib/lib/day_night_timepicker_ios.dart
+++ b/lib/lib/day_night_timepicker_ios.dart
@@ -64,10 +64,8 @@ class _DayNightTimePickerIosState extends State<DayNightTimePickerIos> {
       minMinute,
       maxMinute,
     );
-    final h = timeState!.widget.is24HrFormat
-        ? timeState!.time.hour
-        : timeState!.time.hourOfPeriod;
 
+    final h = timeState!.time.hour;
     final m = timeState!.time.minute;
 
     _hourController =


### PR DESCRIPTION
Issue details here: https://github.com/subhamayd2/day_night_time_picker/issues/54

### Replicating the bug
- Show time picker widget with the following values
  - `iosStylePicker` set to `true`
  - `value` of TimeOfDay in the P.M. time period (ie: 4 PM)
- Swipe on the "hours" wheel -> Notice am/pm change

### Why does this happen
Notice that when you adjust the hours, the "am" text gets selected. This is because the hour is initialized with respect to the time period (meaning, out of 12 instead of 24). However, the wheel itself has 24 options, not 12.

### How to fix this
Simply disregrard the time period when calculating the "initial hour" for the `DisplayWheel`