### PR TITLE
Make it more customizable

### DIFF
--- a/lib/lib/ampm.dart
+++ b/lib/lib/ampm.dart
@@ -44,7 +44,7 @@ class AmPm extends StatelessWidget {
               child: Opacity(
                 opacity: !isAm ? unselectedOpacity : 1,
                 child: Text(
-                  'am',
+                  timeState.widget.amLabel,
                   style: _style.copyWith(
                     color: isAm ? accentColor : unselectedColor,
                     fontWeight: isAm ? FontWeight.bold : null,
@@ -67,7 +67,7 @@ class AmPm extends StatelessWidget {
               child: Opacity(
                 opacity: isAm ? unselectedOpacity : 1,
                 child: Text(
-                  'pm',
+                  timeState.widget.pmLabel,
                   style: _style.copyWith(
                     color: !isAm ? accentColor : unselectedColor,
                     fontWeight: !isAm ? FontWeight.bold : null,

--- a/lib/lib/common/action_buttons.dart
+++ b/lib/lib/common/action_buttons.dart
@@ -20,38 +20,21 @@ class ActionButtons extends StatelessWidget {
       );
     }
 
-    if (!timeState.widget.showCancelButton) {
-      return Expanded(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: <Widget>[
-            TextButton(
-              onPressed: timeState.onOk,
-              style: timeState.widget.buttonStyle ?? defaultButtonStyle,
-              child: Text(
-                timeState.widget.okText,
-                style: timeState.widget.okStyle,
-              ),
-            ),
-          ],
-        ),
-      );
-    }
-
-    return Expanded(
+    return IntrinsicHeight(
       child: Row(
         mainAxisAlignment: MainAxisAlignment.end,
         children: <Widget>[
-          TextButton(
-            style: (timeState.widget.cancelButtonStyle ??
-                    timeState.widget.buttonStyle) ??
-                defaultButtonStyle,
-            onPressed: timeState.onCancel,
-            child: Text(
-              timeState.widget.cancelText,
-              style: timeState.widget.cancelStyle,
+          if (timeState.widget.showCancelButton)
+            TextButton(
+              style: (timeState.widget.cancelButtonStyle ??
+                      timeState.widget.buttonStyle) ??
+                  defaultButtonStyle,
+              onPressed: timeState.onCancel,
+              child: Text(
+                timeState.widget.cancelText,
+                style: timeState.widget.cancelStyle,
+              ),
             ),
-          ),
           SizedBox(width: timeState.widget.buttonsSpacing ?? 0),
           TextButton(
             onPressed: timeState.onOk,

--- a/lib/lib/common/display_wheel.dart
+++ b/lib/lib/common/display_wheel.dart
@@ -56,9 +56,10 @@ class DisplayWheel extends StatelessWidget {
           itemExtent: 36,
           physics: disabled
               ? const NeverScrollableScrollPhysics()
-              : const FixedExtentScrollPhysics(),
+              : const FixedExtentScrollPhysics(parent: BouncingScrollPhysics()),
           overAndUnderCenterOpacity: disabled ? 0 : 0.25,
           perspective: 0.01,
+          magnification: timeState.widget.wheelMagnification,
           onSelectedItemChanged: onChange,
           childDelegate: ListWheelChildBuilderDelegate(
             childCount: items.length,

--- a/lib/lib/common/wrapper_container.dart
+++ b/lib/lib/common/wrapper_container.dart
@@ -21,11 +21,7 @@ class WrapperContainer extends StatelessWidget {
       child: Container(
         height: height,
         color: backgroundColor,
-        padding: const EdgeInsets.only(
-          left: 12.0,
-          top: 12.0,
-          right: 12.0,
-        ),
+        padding: timeState.widget.contentPadding,
         child: child,
       ),
     );

--- a/lib/lib/common/wrapper_container.dart
+++ b/lib/lib/common/wrapper_container.dart
@@ -6,32 +6,28 @@ class WrapperContainer extends StatelessWidget {
   /// The child [Widget] to render
   final Widget child;
 
-  /// The height of the Wheel section
-  final double? heightOfWheel;
-
   /// Constructor for the [Widget]
   const WrapperContainer({
     Key? key,
     required this.child,
-    this.heightOfWheel,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final timeState = TimeModelBinding.of(context);
-    final height = timeState.widget.is24HrFormat
-        ? 200.0
-        : timeState.widget.wheelHeight ?? 240.0;
-
-    return Container(
-      height: height,
-      color: Theme.of(context).cardColor,
-      padding: const EdgeInsets.only(
-        left: 12.0,
-        top: 12.0,
-        right: 12.0,
+    var timeState = TimeModelBinding.of(context);
+    double height = timeState.widget.height;
+    Color backgroundColor = timeState.widget.backgroundColor;
+    return Expanded(
+      child: Container(
+        height: height,
+        color: backgroundColor,
+        padding: const EdgeInsets.only(
+          left: 12.0,
+          top: 12.0,
+          right: 12.0,
+        ),
+        child: child,
       ),
-      child: child,
     );
   }
 }

--- a/lib/lib/common/wrapper_dialog.dart
+++ b/lib/lib/common/wrapper_dialog.dart
@@ -18,6 +18,7 @@ class WrapperDialog extends StatelessWidget {
     final timeState = TimeModelBinding.of(context);
     final borderRadius = timeState.widget.borderRadius ?? BORDER_RADIUS;
     final elevation = timeState.widget.elevation ?? ELEVATION;
+    final backgroundColor = timeState.widget.backgroundColor;
 
     return Dialog(
       insetPadding: timeState.widget.dialogInsetPadding,
@@ -27,9 +28,7 @@ class WrapperDialog extends StatelessWidget {
       elevation: elevation,
       child: ClipRRect(
         borderRadius: BorderRadius.circular(borderRadius),
-        child: SizedBox(
-          width: timeState.widget.width,
-          height: timeState.widget.height,
+        child: IntrinsicHeight(
           child: child,
         ),
       ),

--- a/lib/lib/day_night_timepicker_android.dart
+++ b/lib/lib/day_night_timepicker_android.dart
@@ -175,7 +175,6 @@ class DayNightTimePickerAndroidState extends State<DayNightTimePickerAndroid> {
                       ),
                       const Spacer(),
                       if (!hideButtons) const ActionButtons(),
-                      const SizedBox(height: 6),
                     ],
                   ),
                 ),

--- a/lib/lib/day_night_timepicker_android.dart
+++ b/lib/lib/day_night_timepicker_android.dart
@@ -61,6 +61,7 @@ class DayNightTimePickerAndroidState extends State<DayNightTimePickerAndroid> {
     final hideButtons = timeState.widget.hideButtons;
 
     Orientation currentOrientation = MediaQuery.of(context).orientation;
+    double height = TimeModelBinding.of(context).widget.height;
 
     double value = timeState.time.hour.roundToDouble();
     if (timeState.selected == SelectedInput.MINUTE) {
@@ -91,61 +92,61 @@ class DayNightTimePickerAndroidState extends State<DayNightTimePickerAndroid> {
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: <Widget>[
                       const AmPm(),
-                      Expanded(
-                        child: Row(
-                          textDirection: ltrMode,
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: <Widget>[
-                            DisplayValue(
-                              onTap: timeState.widget.disableHour!
-                                  ? null
-                                  : () {
+                      const SizedBox(height: 8),
+                      const Spacer(),
+                      Row(
+                        textDirection: ltrMode,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
+                          DisplayValue(
+                            onTap: timeState.widget.disableHour!
+                                ? null
+                                : () {
+                                    timeState.onSelectedInputChange(
+                                      SelectedInput.HOUR,
+                                    );
+                                  },
+                            value: hourValue.toString().padLeft(2, '0'),
+                            isSelected:
+                                timeState.selected == SelectedInput.HOUR,
+                          ),
+                          const DisplayValue(
+                            value: ':',
+                          ),
+                          DisplayValue(
+                            onTap: timeState.widget.disableMinute!
+                                ? null
+                                : () {
+                                    timeState.onSelectedInputChange(
+                                      SelectedInput.MINUTE,
+                                    );
+                                  },
+                            value: timeState.time.minute
+                                .toString()
+                                .padLeft(2, '0'),
+                            isSelected:
+                                timeState.selected == SelectedInput.MINUTE,
+                          ),
+                          ...timeState.widget.showSecondSelector
+                              ? [
+                                  const DisplayValue(
+                                    value: ':',
+                                  ),
+                                  DisplayValue(
+                                    onTap: () {
                                       timeState.onSelectedInputChange(
-                                        SelectedInput.HOUR,
+                                        SelectedInput.SECOND,
                                       );
                                     },
-                              value: hourValue.toString().padLeft(2, '0'),
-                              isSelected:
-                                  timeState.selected == SelectedInput.HOUR,
-                            ),
-                            const DisplayValue(
-                              value: ':',
-                            ),
-                            DisplayValue(
-                              onTap: timeState.widget.disableMinute!
-                                  ? null
-                                  : () {
-                                      timeState.onSelectedInputChange(
-                                        SelectedInput.MINUTE,
-                                      );
-                                    },
-                              value: timeState.time.minute
-                                  .toString()
-                                  .padLeft(2, '0'),
-                              isSelected:
-                                  timeState.selected == SelectedInput.MINUTE,
-                            ),
-                            ...timeState.widget.showSecondSelector
-                                ? [
-                                    const DisplayValue(
-                                      value: ':',
-                                    ),
-                                    DisplayValue(
-                                      onTap: () {
-                                        timeState.onSelectedInputChange(
-                                          SelectedInput.SECOND,
-                                        );
-                                      },
-                                      value: timeState.time.second
-                                          .toString()
-                                          .padLeft(2, '0'),
-                                      isSelected: timeState.selected ==
-                                          SelectedInput.SECOND,
-                                    ),
-                                  ]
-                                : []
-                          ],
-                        ),
+                                    value: timeState.time.second
+                                        .toString()
+                                        .padLeft(2, '0'),
+                                    isSelected: timeState.selected ==
+                                        SelectedInput.SECOND,
+                                  ),
+                                ]
+                              : []
+                        ],
                       ),
                       Slider(
                         onChangeEnd: (value) {
@@ -172,7 +173,9 @@ class DayNightTimePickerAndroidState extends State<DayNightTimePickerAndroid> {
                         activeColor: color,
                         inactiveColor: color.withAlpha(55),
                       ),
+                      const Spacer(),
                       if (!hideButtons) const ActionButtons(),
+                      const SizedBox(height: 6),
                     ],
                   ),
                 ),

--- a/lib/lib/day_night_timepicker_android.dart
+++ b/lib/lib/day_night_timepicker_android.dart
@@ -30,10 +30,16 @@ class DayNightTimePickerAndroid extends StatefulWidget {
 
 /// Picker state class
 class DayNightTimePickerAndroidState extends State<DayNightTimePickerAndroid> {
+  late TimeModelBindingState timeState;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    timeState = TimeModelBinding.of(context);
+  }
+
   @override
   Widget build(BuildContext context) {
-    final timeState = TimeModelBinding.of(context);
-
     double min =
         getMin(timeState.widget.minMinute, timeState.widget.minuteInterval);
     double max =
@@ -61,7 +67,6 @@ class DayNightTimePickerAndroidState extends State<DayNightTimePickerAndroid> {
     final hideButtons = timeState.widget.hideButtons;
 
     Orientation currentOrientation = MediaQuery.of(context).orientation;
-    double height = TimeModelBinding.of(context).widget.height;
 
     double value = timeState.time.hour.roundToDouble();
     if (timeState.selected == SelectedInput.MINUTE) {
@@ -149,22 +154,7 @@ class DayNightTimePickerAndroidState extends State<DayNightTimePickerAndroid> {
                         ],
                       ),
                       Slider(
-                        onChangeEnd: (value) {
-                          if (!timeState.widget.disableAutoFocusToNextInput) {
-                            if (timeState.selected == SelectedInput.HOUR) {
-                              timeState
-                                  .onSelectedInputChange(SelectedInput.MINUTE);
-                            } else if (timeState.selected ==
-                                    SelectedInput.MINUTE &&
-                                timeState.widget.showSecondSelector) {
-                              timeState
-                                  .onSelectedInputChange(SelectedInput.SECOND);
-                            }
-                          }
-                          if (timeState.widget.isOnValueChangeMode) {
-                            timeState.onOk();
-                          }
-                        },
+                        onChangeEnd: (_) => onChangedSlider(),
                         value: value,
                         onChanged: timeState.onTimeChange,
                         min: min,
@@ -184,5 +174,23 @@ class DayNightTimePickerAndroidState extends State<DayNightTimePickerAndroid> {
         ),
       ),
     );
+  }
+
+  onChangedSlider() {
+    if (!timeState.widget.disableAutoFocusToNextInput) {
+      if (timeState.selected == SelectedInput.HOUR) {
+        if (!(timeState.widget.disableMinute ?? false)) {
+          timeState.onSelectedInputChange(SelectedInput.MINUTE);
+        } else if (timeState.widget.showSecondSelector) {
+          timeState.onSelectedInputChange(SelectedInput.SECOND);
+        }
+      } else if (timeState.selected == SelectedInput.MINUTE &&
+          timeState.widget.showSecondSelector) {
+        timeState.onSelectedInputChange(SelectedInput.SECOND);
+      }
+    }
+    if (timeState.widget.isOnValueChangeMode) {
+      timeState.onOk();
+    }
   }
 }

--- a/lib/lib/day_night_timepicker_ios.dart
+++ b/lib/lib/day_night_timepicker_ios.dart
@@ -216,6 +216,7 @@ class _DayNightTimePickerIosState extends State<DayNightTimePickerIos> {
   @override
   Widget build(BuildContext context) {
     Orientation currentOrientation = MediaQuery.of(context).orientation;
+    double wheelHeight = TimeModelBinding.of(context).widget.wheelHeight;
 
     return Center(
       child: SingleChildScrollView(
@@ -239,7 +240,9 @@ class _DayNightTimePickerIosState extends State<DayNightTimePickerIos> {
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: <Widget>[
                       const AmPm(),
-                      Expanded(
+                      const Spacer(),
+                      SizedBox(
+                        height: wheelHeight,
                         child: Row(
                           textDirection: ltrMode,
                           mainAxisAlignment: MainAxisAlignment.center,
@@ -255,7 +258,10 @@ class _DayNightTimePickerIosState extends State<DayNightTimePickerIos> {
                               disabled: timeState!.widget.disableHour!,
                               getModifiedLabel: getModifiedLabel,
                             ),
-                            Text(timeState!.widget.hourLabel!),
+                            Text(
+                              timeState!.widget.hourLabel!,
+                              style: timeState!.widget.hmsStyle,
+                            ),
                             DisplayWheel(
                               controller: _minuteController!,
                               items: minutes,
@@ -267,7 +273,10 @@ class _DayNightTimePickerIosState extends State<DayNightTimePickerIos> {
                               },
                               disabled: timeState!.widget.disableMinute!,
                             ),
-                            Text(timeState!.widget.minuteLabel!),
+                            Text(
+                              timeState!.widget.minuteLabel!,
+                              style: timeState!.widget.hmsStyle,
+                            ),
                             ...(timeState!.widget.showSecondSelector
                                 ? [
                                     DisplayWheel(
@@ -281,13 +290,18 @@ class _DayNightTimePickerIosState extends State<DayNightTimePickerIos> {
                                         );
                                       },
                                     ),
-                                    Text(timeState!.widget.secondLabel!),
+                                    Text(
+                                      timeState!.widget.secondLabel!,
+                                      style: timeState!.widget.hmsStyle,
+                                    ),
                                   ]
                                 : []),
                           ],
                         ),
                       ),
-                      if (!timeState!.widget.hideButtons) const ActionButtons()
+                      const Spacer(),
+                      if (!timeState!.widget.hideButtons) const ActionButtons(),
+                      const SizedBox(height: 6),
                     ],
                   ),
                 ),

--- a/lib/lib/day_night_timepicker_ios.dart
+++ b/lib/lib/day_night_timepicker_ios.dart
@@ -301,7 +301,6 @@ class _DayNightTimePickerIosState extends State<DayNightTimePickerIos> {
                       ),
                       const Spacer(),
                       if (!timeState!.widget.hideButtons) const ActionButtons(),
-                      const SizedBox(height: 6),
                     ],
                   ),
                 ),

--- a/lib/lib/day_night_timepicker_ios.dart
+++ b/lib/lib/day_night_timepicker_ios.dart
@@ -113,7 +113,11 @@ class _DayNightTimePickerIosState extends State<DayNightTimePickerIos> {
               WidgetsBinding.instance.addPostFrameCallback((_) {
                 if (!_hourController!.position.isScrollingNotifier.value) {
                   if (!timeState!.widget.disableAutoFocusToNextInput) {
-                    timeState!.onSelectedInputChange(SelectedInput.MINUTE);
+                    if (!(timeState!.widget.disableMinute ?? false)) {
+                      timeState!.onSelectedInputChange(SelectedInput.MINUTE);
+                    } else if (timeState!.widget.showSecondSelector) {
+                      timeState!.onSelectedInputChange(SelectedInput.SECOND);
+                    }
                   }
                   if (timeState!.widget.isOnValueChangeMode) {
                     timeState!.onOk();

--- a/lib/lib/daynight_timepicker.dart
+++ b/lib/lib/daynight_timepicker.dart
@@ -50,6 +50,8 @@ import 'package:flutter/material.dart';
 ///
 /// **dialogInsetPadding** - Inset padding of the [Modal] in EdgeInsets. Defaults to `EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0)`.
 ///
+/// **contentPadding** - Inset padding of the time content (exclude the night/sun animation) in EdgeInsets. Defaults to `EdgeInsets.symmetric(horizontal: 12.0, vertical: 12.0)`.
+///
 /// **barrierDismissible** - Whether clicking outside should dismiss the [Modal]. Defaults to `true`.
 ///
 /// **iosStylePicker** - Whether to display a IOS style picker (Not exactly the same). Defaults to `false`.
@@ -131,6 +133,8 @@ dynamic showPicker({
   double? elevation,
   EdgeInsets? dialogInsetPadding =
       const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
+  EdgeInsets contentPadding =
+      const EdgeInsets.symmetric(horizontal: 12.0, vertical: 12.0),
   bool barrierDismissible = true,
   bool iosStylePicker = false,
   bool displayHeader = true,
@@ -220,6 +224,7 @@ dynamic showPicker({
         borderRadius: borderRadius,
         elevation: elevation,
         dialogInsetPadding: dialogInsetPadding,
+        contentPadding: contentPadding,
         minuteInterval: minuteInterval,
         secondInterval: secondInterval,
         disableMinute: disableMinute,

--- a/lib/lib/daynight_timepicker.dart
+++ b/lib/lib/daynight_timepicker.dart
@@ -26,15 +26,21 @@ import 'package:flutter/material.dart';
 ///
 /// **unselectedColor** - Color applied unselected options (am/pm, hour/minute). Defaults to `Colors.grey`.
 ///
-/// **cancelText** - Text displayed for the Cancel button. Defaults to `cancel`.
+/// **cancelText** - Text displayed for the Cancel button. Defaults to `Cancel`.
 ///
-/// **okText** - Text displayed for the Ok button. Defaults to `ok`.
+/// **okText** - Text displayed for the Ok button. Defaults to `Ok`.
+///
+/// **amLabel** - Text displayed for the 'am' text. Defaults to `am`.
+///
+/// **pmLabel** - Text displayed for the 'pm' text. Defaults to `pm`.
 ///
 /// **sunAsset** - Image asset used for the Sun. Default asset provided.
 ///
 /// **moonAsset** - Image asset used for the Moon. Default asset provided.
 ///
 /// **blurredBackground** - Whether to blur the background of the [Modal]. Defaults to `false`.
+///
+/// **backgroundColor** - Set to the background of the [Modal]. Defaults to `Colors.white`.
 ///
 /// **barrierColor** - Color of the background of the [Modal]. Defaults to `Colors.black45`.
 ///
@@ -84,13 +90,17 @@ import 'package:flutter/material.dart';
 ///
 /// **cancelStyle** - Cancel button's text style. Defaults to `const TextStyle(fontWeight: FontWeight.bold)`.
 ///
+/// **hmsStyle** - Set text style of 'hours', 'minutes', and 'seconds'. Defaults to `null`.
+///
 /// **hideButtons** - Whether to hide the buttons (ok and cancel). Defaults to `false`.
 ///
 /// **disableAutoFocusToNextInput** - Whether to disable the auto focus to the next input after current input is selected. Defaults to `false`.
 ///
 /// **width** - Fixed width of the Picker container. Defaults to `300` but `350` for `iosStyle`.
 ///
-/// **height** - Fixed height of the Picker container. Defaults to `400`.
+/// **height** - Fixed height of the Picker container. Defaults to `245`.
+///
+/// **wheelHeight** - Fixed height of the iOS style scrolling wheel. Defaults to `100`.
 ///
 /// **showSecondSelector** - Whether to use the second selector as well. Defaults to `false`.
 ///
@@ -110,6 +120,8 @@ dynamic showPicker({
   bool isOnChangeValueMode = false,
   String cancelText = 'Cancel',
   String okText = 'Ok',
+  String amLabel = 'am',
+  String pmLabel = 'pm',
   Image? sunAsset,
   Image? moonAsset,
   bool blurredBackground = false,
@@ -140,20 +152,23 @@ dynamic showPicker({
   double maxHour = double.infinity,
   TextStyle okStyle = const TextStyle(fontWeight: FontWeight.bold),
   TextStyle cancelStyle = const TextStyle(fontWeight: FontWeight.bold),
+  TextStyle? hmsStyle,
   ButtonStyle? buttonStyle,
   ButtonStyle? cancelButtonStyle,
   double? buttonsSpacing,
   bool hideButtons = false,
   bool disableAutoFocusToNextInput = false,
   double width = 300,
-  double height = 400,
+  double? height,
   bool showSecondSelector = false,
   double? wheelHeight,
+  double? wheelMagnification,
   bool showCancelButton = true,
   sunrise = const TimeOfDay(hour: 6, minute: 0),
   sunset = const TimeOfDay(hour: 18, minute: 0),
   duskSpanInMinutes = 120,
   RouteSettings? settings,
+  Color? backgroundColor,
 }) {
   if (minHour == double.infinity) {
     minHour = 0;
@@ -196,9 +211,12 @@ dynamic showPicker({
         unselectedColor: unselectedColor,
         cancelText: cancelText,
         okText: okText,
+        amLabel: amLabel,
+        pmLabel: pmLabel,
         sunAsset: sunAsset,
         moonAsset: moonAsset,
         blurredBackground: blurredBackground,
+        backgroundColor: backgroundColor,
         borderRadius: borderRadius,
         elevation: elevation,
         dialogInsetPadding: dialogInsetPadding,
@@ -215,6 +233,7 @@ dynamic showPicker({
         focusMinutePicker: focusMinutePicker,
         okStyle: okStyle,
         cancelStyle: cancelStyle,
+        hmsStyle: hmsStyle,
         buttonStyle: buttonStyle,
         cancelButtonStyle: cancelButtonStyle,
         buttonsSpacing: buttonsSpacing,
@@ -227,6 +246,7 @@ dynamic showPicker({
         height: height,
         showSecondSelector: showSecondSelector,
         wheelHeight: wheelHeight,
+        wheelMagnification: wheelMagnification,
         isOnValueChangeMode: isOnChangeValueMode,
         hideButtons: hideButtons,
         showCancelButton: showCancelButton,

--- a/lib/lib/state/state_container.dart
+++ b/lib/lib/state/state_container.dart
@@ -56,6 +56,9 @@ class TimeModelBinding extends StatefulWidget {
   /// Inset padding of the [Modal] in [EdgeInsets].
   final EdgeInsets? dialogInsetPadding;
 
+  /// Inset padding of the content in [EdgeInsets].
+  final EdgeInsets? contentPadding;
+
   /// Steps interval while changing [minute].
   final TimePickerInterval? minuteInterval;
 
@@ -191,6 +194,7 @@ class TimeModelBinding extends StatefulWidget {
     this.borderRadius,
     this.elevation,
     this.dialogInsetPadding,
+    this.contentPadding,
     this.minuteInterval,
     this.secondInterval,
     this.disableMinute,
@@ -225,7 +229,7 @@ class TimeModelBinding extends StatefulWidget {
     this.sunrise,
     this.sunset,
     this.duskSpanInMinutes,
-  })  : height = height ?? 245,
+  })  : height = height ?? 260,
         wheelHeight = wheelHeight ?? 100,
         wheelMagnification = wheelMagnification ?? 1.0,
         backgroundColor = backgroundColor ?? Colors.white,

--- a/lib/lib/state/state_container.dart
+++ b/lib/lib/state/state_container.dart
@@ -44,6 +44,9 @@ class TimeModelBinding extends StatefulWidget {
   /// Whether to blur the background of the [Modal].
   final bool blurredBackground;
 
+  /// Set the background color of the [Modal].
+  final Color backgroundColor;
+
   /// Border radius of the [Container] in [double].
   final double? borderRadius;
 
@@ -92,6 +95,15 @@ class TimeModelBinding extends StatefulWidget {
   /// Label for the `second` text.
   final String? secondLabel;
 
+  /// Label for the 'am' text.
+  final String amLabel;
+
+  /// Label for the 'pm' text.
+  final String pmLabel;
+
+  /// Text style for the 'hours', 'minutes', and 'seconds'
+  final TextStyle? hmsStyle;
+
   /// Whether the widget is displayed as a popup or inline
   final bool isInlineWidget;
 
@@ -124,7 +136,10 @@ class TimeModelBinding extends StatefulWidget {
   final Widget child;
 
   /// The height of the Wheel section
-  double? wheelHeight;
+  double wheelHeight;
+
+  /// The magnification of the Wheel section
+  double wheelMagnification;
 
   /// Whether to hide the buttons (ok and cancel). Defaults to `false`.
   bool hideButtons;
@@ -172,6 +187,7 @@ class TimeModelBinding extends StatefulWidget {
     this.sunAsset,
     this.moonAsset,
     this.blurredBackground = false,
+    Color? backgroundColor,
     this.borderRadius,
     this.elevation,
     this.dialogInsetPadding,
@@ -188,24 +204,32 @@ class TimeModelBinding extends StatefulWidget {
     this.hourLabel,
     this.minuteLabel,
     this.secondLabel,
+    this.amLabel = 'am',
+    this.pmLabel = 'pm',
     this.isInlineWidget = false,
     this.focusMinutePicker = false,
     this.okStyle = const TextStyle(fontWeight: FontWeight.bold),
     this.cancelStyle = const TextStyle(fontWeight: FontWeight.bold),
+    this.hmsStyle,
     this.buttonStyle,
     this.cancelButtonStyle,
     this.buttonsSpacing,
-    this.wheelHeight,
+    double? wheelHeight,
+    double? wheelMagnification,
     this.hideButtons = false,
     this.disableAutoFocusToNextInput = false,
     this.width = 0,
-    this.height = 0,
+    double? height,
     this.showSecondSelector = false,
     this.showCancelButton = true,
     this.sunrise,
     this.sunset,
     this.duskSpanInMinutes,
-  }) : super(key: key);
+  })  : height = height ?? 245,
+        wheelHeight = wheelHeight ?? 100,
+        wheelMagnification = wheelMagnification ?? 1.0,
+        backgroundColor = backgroundColor ?? Colors.white,
+        super(key: key);
 
   @override
   TimeModelBindingState createState() => TimeModelBindingState();


### PR DESCRIPTION
Now you can fully customize the widget to adapt dark mode

- Add an option to change 'am' and 'pm' label
- Time is now responsive and stay at center as height grows
- Add an option to adjust wheel magnification
- Make wheel bounce when overscrolling like native iOS scroll physics
- Add an option to customize text style for 'hours', 'minutes', 'seconds' labels
- Add an option to change background color of modal
- Fix auto input focus bug #119 